### PR TITLE
issue has to do with background placement

### DIFF
--- a/src/app/words/words.component.html
+++ b/src/app/words/words.component.html
@@ -1,31 +1,32 @@
 <div class="page">
-<h1 class="sunrise">Asheville Ipsum</h1>
-<h2 class="sunrise">Asheville Infused Lorem Ipusm Generator</h2>
+  <h1 class="sunrise">Asheville Ipsum</h1>
+  <h2 class="sunrise">Asheville Infused Lorem Ipusm Generator</h2>
   <h3 class="sunrise">Ditch that boring ipsum for some auto-generated, beer infused,</h3>
   <h3 class="sunrise">funky smelling, hippster weirdness.</h3>
-<div class="inputs">
-<form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
-    <div class="form-group" id="numberOfParagraphs">
+  <div class="inputs">
+    <form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
+      <div class="form-group" id="numberOfParagraphs">
         <label>Number of Paragraphs</label>
         <input type="text" id="number-field" formControlName="numberOfParagraphs" class="form-control" />
         <div class="updown">
           <i class="arrow-up" (click)="incrementParagraphs()"></i>
           <i class="arrow-down" (click)="decrementParagraphs()"></i>
         </div>
-    </div>
-  <div class="form-group" id="short-medium-long">
-    <mat-radio-group aria-label="Select an option" formControlName="numberOfWords" class="form-control" >
-      <mat-radio-button class="radio-button" value="25">Short</mat-radio-button>
-      <mat-radio-button class="radio-button" value="50">Medium</mat-radio-button>
-      <mat-radio-button class="radio-button" value="100">Long</mat-radio-button>
-    </mat-radio-group>
+      </div>
+      <div class="form-group" id="short-medium-long">
+        <mat-radio-group aria-label="Select an option" formControlName="numberOfWords" class="form-control">
+          <mat-radio-button class="radio-button" value="25">Short</mat-radio-button>
+          <mat-radio-button class="radio-button" value="50">Medium</mat-radio-button>
+          <mat-radio-button class="radio-button" value="100">Long</mat-radio-button>
+        </mat-radio-group>
+      </div>
+      <mat-checkbox formControlName="moreBeer" class="more-check-box">Extra Beer</mat-checkbox>
+      <mat-checkbox formControlName="moreFunk" class="more-check-box">Extra Funky</mat-checkbox>
+      <div class="form-group">
+        <button class="btn btn-primary" id="submit-button">Generate Weirdness</button>
+      </div>
+    </form>
   </div>
-    <mat-checkbox formControlName="moreBeer" class="more-check-box">Extra Beer</mat-checkbox>
-    <mat-checkbox formControlName="moreFunk" class="more-check-box">Extra Funky</mat-checkbox>
-  <div class="form-group">
-      <button class="btn btn-primary" id="submit-button">Generate Weirdness</button>
-  </div>
-</form>
+  <p class="content" *ngFor="let paragraph of paragraphs">{{ paragraph }}<br><br></p>
 </div>
-
-<div class="content" *ngFor="let paragraph of paragraphs">{{ paragraph }}<br><br></div>
+<div class="page-bg"></div>

--- a/src/app/words/words.component.scss
+++ b/src/app/words/words.component.scss
@@ -80,9 +80,9 @@ i {
 
 .updown {
 	display: flex;
-    flex-direction: column;
-    max-width: 10px;
-    margin-left: 10px;
+  flex-direction: column;
+  max-width: 10px;
+  margin-left: 10px;
 }
 
 .arrow-up {
@@ -105,11 +105,11 @@ i {
 .page {
   min-height: 100vh;
   position: relative;
+  z-index: 20;
 }
-.page:before {
-  content: '';
+.page-bg {
   opacity: .2;
-  position: absolute;
+  position: fixed;
   height: 100%;
   width: 100%;
   top: 0;


### PR DESCRIPTION
Took background out of `.page`. When `:before` the bg blocked text highlighting. When `:after` it blocked the input buttons. Taking it out of `.page` made it so that it does not get the height of `.page` anymore. So I set it to `position: fixed` so that you could always see `stay weird` can try and figure something else out if this isn't the look you want. If you want I could just go and photoshop the image to 20% opacity so that we could just use it as a regular background-image.